### PR TITLE
Don't autorole people on login

### DIFF
--- a/modules/events.rb
+++ b/modules/events.rb
@@ -23,9 +23,4 @@ module EventHandlers
       end
     end
   end
-
-  # add disciple role on member join
-  member_join do |event|
-    event.server.member(event.user.id).add_role(CONFIG['roles']['disciple'])
-  end
 end

--- a/modules/general.rb
+++ b/modules/general.rb
@@ -61,7 +61,7 @@ module GeneralCommands
           aliases: [:roles],
           channels: [CONFIG['bot_channel'], CONFIG['testing_channel']],
           description: 'Add class roles to see channels for each class') do |event, action, *roles|
-    # add disciples role here temporarily since event is broken
+    # add disciples role here to allow access to server
     event.author.add_role(CONFIG['roles']['disciple'])
 
     if %w(add remove).include? action


### PR DESCRIPTION
This requires new members to add class roles to access the server.