### PR TITLE
Updated forecasting command for 2026-27 academic year

### DIFF
--- a/modules/general.rb
+++ b/modules/general.rb
@@ -94,7 +94,7 @@ module Bishop
       end
 
       command(:forecasting) do
-        'https://docs.google.com/spreadsheets/d/1tIvPdUo9_ZEGyHQqMjZLt5rYz70djzqcRU4HCeAKk4k/htmlview'
+        'https://docs.google.com/spreadsheets/d/1yna7wccuV_dW6KYd1dzRgs_VNE5TzkJvfPgDxv1h0hM/htmlview'
       end
 
       command(:lug, aliases: %i[plug]) do


### PR DESCRIPTION
I had replaced the Google Sheets link in `modules/general.rb` to point to the most recent version of the School of EECS' forecasting sheet for the 2026-27 academic year so the `!forecasting` command will show this new sheet instead of the current one for the current/past academic year.